### PR TITLE
Support for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+    "name": "nanodocumet/nanodicom",
+    "description": "A PHP DICOM toolkit",
+    "homepage": "http://www.nanodicom.org/",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Jorge \"Nano\" Documet",
+            "homepage": "http://www.nanodicom.org/",
+            "role": "Developer"
+        }
+    ],
+    "autoload": {
+        "files": [ "nanodicom.php"]
+    },
+    "require": {
+        "php": ">=5.2.6"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "autoload": {
-        "files": [ "nanodicom.php"]
+        "classmap": [ "nanodicom.php" ]
     },
     "require": {
         "php": ">=5.2.6"


### PR DESCRIPTION
This patch adds a composer.json that can be used to add nanodicom to packagist.org later on.