### PR TITLE
Rename parameters to fix nanodicom under php7

### DIFF
--- a/nanodicom/core.php
+++ b/nanodicom/core.php
@@ -1079,7 +1079,7 @@ abstract class Nanodicom_Core {
 	 * @param	mixed
 	 * @return	void
 	 */
-	protected function _dummy($arg1 = NULL, $arg2 = NULL, $arg2 = NULL, $arg3 = NULL, $arg4 = NULL, $arg5 = NULL)
+	protected function _dummy($arg1 = NULL, $arg2 = NULL, $arg3 = NULL, $arg4 = NULL, $arg5 = NULL, $arg6 = NULL)
 	{
 	}
 	


### PR DESCRIPTION
Without this patch running nanodicom under php7 throws a
"Redefinition of parameter" compile time error.
