### PR TITLE
Patch bytes preventing access to sequences below root

### DIFF
--- a/nanodicom/core.php
+++ b/nanodicom/core.php
@@ -573,6 +573,7 @@ abstract class Nanodicom_Core {
 	 */
 	public function value($group = NULL, $element = NULL, $new_value = NULL, $binary = FALSE)
 	{
+		$this->_parent_vr='';
 		return $this->dataset_value($this->_dataset, $group, $element, $new_value, $binary);
 	}
 


### PR DESCRIPTION
I have hit a roadblock when working using nanodicom. SequenceOfUltrasoundRegions 	(0018,6011) was unavailable to what turns out was parent_vr persisting from parsing, meaning that this tag was being read as byte.
Im unable to fix the root of the problem so here's 1 line that should fix most of its occurrences

THE BUG:
parent_vr being a global variable for a file means that after reading ('OB', 'OW', 'OX') data from a dicom file and not reading its contents will lead to some tags of type SQ not working.